### PR TITLE
Add CSV output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The script `weekly_line_counts.py` requires Python 3 and the `GitPython` package
 pip install gitpython
 ```
 
-Run the script by providing the repository URL and the path to the file you want to inspect. Optionally specify the branch (defaults to `main`).
+Run the script by providing the repository URL and the path to the file you want to inspect. Optionally specify the branch (defaults to `main`). Add `--csv` to save the results to a CSV file instead of printing them to the console.
 
 ```bash
-python weekly_line_counts.py <repo_url> <path/to/file> [--branch BRANCH]
+python weekly_line_counts.py <repo_url> <path/to/file> [--branch BRANCH] [--csv output.csv]
 ```
 
-The output will list dates (one per week) and the corresponding number of lines in the chosen file at that point in the repository history.
+Without `--csv`, the output will list dates (one per week) and the corresponding number of lines in the chosen file at that point in the repository history.

--- a/weekly_line_counts.py
+++ b/weekly_line_counts.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime, timedelta
 from git import Repo, exc
+import csv
 
 
 def clone_or_open_repo(url, path):
@@ -27,7 +28,7 @@ def count_lines_in_commit(commit, file_path):
         return None
 
 
-def main(repo_url, file_path, branch='main'):
+def main(repo_url, file_path, branch='main', csv_path=None):
     repo = clone_or_open_repo(repo_url, 'repo')
     results = []
     start = datetime(2023, 1, 1)
@@ -39,8 +40,14 @@ def main(repo_url, file_path, branch='main'):
             if count is not None:
                 results.append((start.strftime('%Y-%m-%d'), count))
         start += timedelta(weeks=1)
-    for date_str, count in results:
-        print(f"{date_str}: {count}")
+    if csv_path:
+        with open(csv_path, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['date', 'lines'])
+            writer.writerows(results)
+    else:
+        for date_str, count in results:
+            print(f"{date_str}: {count}")
 
 
 if __name__ == '__main__':
@@ -50,6 +57,7 @@ if __name__ == '__main__':
     parser.add_argument('repo_url', help='URL of the GitHub repository')
     parser.add_argument('file_path', help='Path to the file within the repository')
     parser.add_argument('--branch', default='main', help='Branch to inspect (default: main)')
+    parser.add_argument('--csv', dest='csv_path', help='Path to output CSV file')
     args = parser.parse_args()
 
-    main(args.repo_url, args.file_path, branch=args.branch)
+    main(args.repo_url, args.file_path, branch=args.branch, csv_path=args.csv_path)


### PR DESCRIPTION
## Summary
- support writing weekly counts to CSV via `--csv`
- document the new command-line option in README

## Testing
- `python -m py_compile weekly_line_counts.py`
- `python weekly_line_counts.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_6855deac7bc883208996bb43af09a7c7